### PR TITLE
table name resolver

### DIFF
--- a/src/Bornlogic.Dapper.Dommel.Json/Bornlogic.Dapper.Dommel.Json.csproj
+++ b/src/Bornlogic.Dapper.Dommel.Json/Bornlogic.Dapper.Dommel.Json.csproj
@@ -3,7 +3,7 @@
     <Description>JSON support for Dommel.</Description>
     <PackageTags>dommel;dapper;json</PackageTags>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.5</Version>
+    <Version>2.0.0</Version>
     <RepositoryUrl>https://github.com/bornlogic/bornlogic-dapper-dommel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/Bornlogic.Dapper.Dommel/AutoMultiMap.cs
+++ b/src/Bornlogic.Dapper.Dommel/AutoMultiMap.cs
@@ -20,7 +20,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static TReturn Get<T1, T2, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -29,6 +29,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -44,7 +45,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static async Task<TReturn> GetAsync<T1, T2, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -53,6 +54,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -69,7 +71,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static TReturn Get<T1, T2, T3, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -78,6 +80,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -94,7 +97,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static async Task<TReturn> GetAsync<T1, T2, T3, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -103,6 +106,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -120,7 +124,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static TReturn Get<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -129,6 +133,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -146,7 +151,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -155,6 +160,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -173,7 +179,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static TReturn Get<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -182,6 +188,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -200,7 +207,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -209,6 +216,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -228,7 +236,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static TReturn Get<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -237,6 +245,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -256,7 +265,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -265,6 +274,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -285,7 +295,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static TReturn Get<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -294,6 +304,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, T7, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -314,7 +325,7 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where T1 : class, TReturn
             where TReturn : class
         {
@@ -323,6 +334,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, T7, TReturn>(results),
                 id,
+                tableNameResolver,
                 transaction);
             return results.Values.FirstOrDefault();
         }
@@ -341,7 +353,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static IEnumerable<TReturn> GetAll<T1, T2, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static IEnumerable<TReturn> GetAll<T1, T2, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -349,6 +361,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -368,7 +381,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -376,6 +389,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -396,7 +410,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static IEnumerable<TReturn> GetAll<T1, T2, T3, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static IEnumerable<TReturn> GetAll<T1, T2, T3, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -404,6 +418,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -424,7 +439,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -432,6 +447,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -453,7 +469,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -461,6 +477,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -482,7 +499,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -490,6 +507,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -512,7 +530,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -520,6 +538,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver, 
                 transaction,
                 buffered);
             return results.Values;
@@ -542,7 +561,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -550,6 +569,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -574,14 +594,14 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
             _ = MultiMap<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(results),
-                id: null,
+                id: null, tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -605,7 +625,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -613,6 +633,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -637,7 +658,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -645,6 +666,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, T7, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;
@@ -669,7 +691,7 @@ namespace Dommel
         /// or when the query is materialized (using <c>ToList()</c> for example).
         /// </param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true)
+        public static async Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
             where T1 : class, TReturn
         {
             var results = new Dictionary<int, T1>();
@@ -677,6 +699,7 @@ namespace Dommel
                 connection,
                 CreateMapDelegate<T1, T2, T3, T4, T5, T6, T7, TReturn>(results),
                 id: null,
+                tableNameResolver,
                 transaction,
                 buffered);
             return results.Values;

--- a/src/Bornlogic.Dapper.Dommel/Bornlogic.Dapper.Dommel.csproj
+++ b/src/Bornlogic.Dapper.Dommel/Bornlogic.Dapper.Dommel.csproj
@@ -3,7 +3,7 @@
     <Description>Simple CRUD operations for Dapper.</Description>
     <PackageTags>dommel;crud;dapper;database;orm</PackageTags>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.5</Version>
+    <Version>2.0.0</Version>
     <RepositoryUrl>https://github.com/bornlogic/bornlogic-dapper-dommel</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/Bornlogic.Dapper.Dommel/Count.cs
+++ b/src/Bornlogic.Dapper.Dommel/Count.cs
@@ -15,9 +15,9 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The number of entities matching the specified predicate.</returns>
-        public static long Count<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null)
+        public static long Count<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
         {
-            var sql = BuildCountAllSql(GetSqlBuilder(connection), typeof(TEntity));
+            var sql = BuildCountAllSql(GetSqlBuilder(connection), typeof(TEntity), tableNameResolver);
             LogQuery<TEntity>(sql);
             return connection.ExecuteScalar<long>(sql, transaction);
         }
@@ -29,9 +29,9 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The number of entities matching the specified predicate.</returns>
-        public static Task<long> CountAsync<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null)
+        public static Task<long> CountAsync<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
         {
-            var sql = BuildCountAllSql(GetSqlBuilder(connection), typeof(TEntity));
+            var sql = BuildCountAllSql(GetSqlBuilder(connection), typeof(TEntity), tableNameResolver);
             LogQuery<TEntity>(sql);
             return connection.ExecuteScalarAsync<long>(sql, transaction);
         }
@@ -44,9 +44,9 @@ namespace Dommel
         /// <param name="predicate">A predicate to filter the results.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The number of entities matching the specified predicate.</returns>
-        public static long Count<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, IDbTransaction? transaction = null)
+        public static long Count<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
         {
-            var sql = BuildCountSql(GetSqlBuilder(connection), predicate, out var parameters);
+            var sql = BuildCountSql(GetSqlBuilder(connection), predicate, tableNameResolver, out var parameters);
             LogQuery<TEntity>(sql);
             return connection.ExecuteScalar<long>(sql, parameters, transaction);
         }
@@ -59,16 +59,16 @@ namespace Dommel
         /// <param name="predicate">A predicate to filter the results.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The number of entities matching the specified predicate.</returns>
-        public static Task<long> CountAsync<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, IDbTransaction? transaction = null)
+        public static Task<long> CountAsync<TEntity>(this IDbConnection connection, Expression<Func<TEntity, bool>> predicate, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
         {
-            var sql = BuildCountSql(GetSqlBuilder(connection), predicate, out var parameters);
+            var sql = BuildCountSql(GetSqlBuilder(connection), predicate, tableNameResolver, out var parameters);
             LogQuery<TEntity>(sql);
             return connection.ExecuteScalarAsync<long>(sql, parameters, transaction);
         }
 
-        internal static string BuildCountAllSql(ISqlBuilder sqlBuilder, Type type)
+        internal static string BuildCountAllSql(ISqlBuilder sqlBuilder, Type type, ITableNameResolver tableNameResolver)
         {
-            var tableName = Resolvers.Table(type, sqlBuilder);
+            var tableName = Resolvers.Table(type, sqlBuilder, tableNameResolver);
             var cacheKey = new QueryCacheKey(QueryCacheType.Count, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
@@ -79,9 +79,9 @@ namespace Dommel
             return sql;
         }
 
-        internal static string BuildCountSql<TEntity>(ISqlBuilder sqlBuilder, Expression<Func<TEntity, bool>> predicate, out DynamicParameters parameters)
+        internal static string BuildCountSql<TEntity>(ISqlBuilder sqlBuilder, Expression<Func<TEntity, bool>> predicate, ITableNameResolver tableNameResolver, out DynamicParameters parameters)
         {
-            var sql = BuildCountAllSql(sqlBuilder, typeof(TEntity));
+            var sql = BuildCountAllSql(sqlBuilder, typeof(TEntity), tableNameResolver);
             sql += CreateSqlExpression<TEntity>(sqlBuilder)
                 .Where(predicate)
                 .ToSql(out parameters);

--- a/src/Bornlogic.Dapper.Dommel/DommelMapper.cs
+++ b/src/Bornlogic.Dapper.Dommel/DommelMapper.cs
@@ -22,7 +22,6 @@ namespace Dommel
         internal static IPropertyResolver PropertyResolver = new DefaultPropertyResolver();
         internal static IKeyPropertyResolver KeyPropertyResolver = new DefaultKeyPropertyResolver();
         internal static IForeignKeyPropertyResolver ForeignKeyPropertyResolver = new DefaultForeignKeyPropertyResolver();
-        internal static ITableNameResolver TableNameResolver = new DefaultTableNameResolver();
         internal static IColumnNameResolver ColumnNameResolver = new DefaultColumnNameResolver();
 
         internal static readonly Dictionary<string, ISqlBuilder> SqlBuilders = new Dictionary<string, ISqlBuilder>
@@ -83,12 +82,7 @@ namespace Dommel
         /// </summary>
         /// <param name="resolver">An instance of <see cref="IForeignKeyPropertyResolver"/>.</param>
         public static void SetForeignKeyPropertyResolver(IForeignKeyPropertyResolver resolver) => ForeignKeyPropertyResolver = resolver;
-
-        /// <summary>
-        /// Sets the <see cref="ITableNameResolver"/> implementation for resolving table names for entities.
-        /// </summary>
-        /// <param name="resolver">An instance of <see cref="ITableNameResolver"/>.</param>
-        public static void SetTableNameResolver(ITableNameResolver resolver) => TableNameResolver = resolver;
+        
 
         /// <summary>
         /// Sets the <see cref="IColumnNameResolver"/> implementation for resolving column names.

--- a/src/Bornlogic.Dapper.Dommel/Get.cs
+++ b/src/Bornlogic.Dapper.Dommel/Get.cs
@@ -19,10 +19,10 @@ namespace Dommel
         /// <param name="id">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static TEntity Get<TEntity>(this IDbConnection connection, object id, IDbTransaction? transaction = null)
+        public static TEntity Get<TEntity>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null)
             where TEntity : class
         {
-            var sql = BuildGetById(GetSqlBuilder(connection), typeof(TEntity), id, out var parameters);
+            var sql = BuildGetById(GetSqlBuilder(connection), typeof(TEntity), id, tableNameResolver, out var parameters);
             LogQuery<TEntity>(sql);
             return connection.QueryFirstOrDefault<TEntity>(sql, parameters, transaction);
         }
@@ -36,17 +36,17 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         ///  <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static async Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object id, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+        public static async Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
             where TEntity : class
         {
-            var sql = BuildGetById(GetSqlBuilder(connection), typeof(TEntity), id, out var parameters);
+            var sql = BuildGetById(GetSqlBuilder(connection), typeof(TEntity), id, tableNameResolver, out var parameters);
             LogQuery<TEntity>(sql);
             return await connection.QueryFirstOrDefaultAsync<TEntity>(new CommandDefinition(sql, parameters, transaction: transaction, cancellationToken: cancellationToken));
         }
 
-        internal static string BuildGetById(ISqlBuilder sqlBuilder, Type type, object id, out DynamicParameters parameters)
+        internal static string BuildGetById(ISqlBuilder sqlBuilder, Type type, object id, ITableNameResolver tableNameResolver, out DynamicParameters parameters)
         {
-            var tableName = Resolvers.Table(type, sqlBuilder);
+            var tableName = Resolvers.Table(type, sqlBuilder, tableNameResolver);
             var cacheKey = new QueryCacheKey(QueryCacheType.Get, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
@@ -75,8 +75,8 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="ids">The id of the entity in the database.</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static TEntity Get<TEntity>(this IDbConnection connection, params object[] ids) where TEntity : class
-            => Get<TEntity>(connection, ids, transaction: null);
+        public static TEntity Get<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, params object[] ids) where TEntity : class
+            => Get<TEntity>(connection, ids, tableNameResolver, transaction: null);
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TEntity"/> with the specified id.
@@ -86,14 +86,14 @@ namespace Dommel
         /// <param name="ids">The id of the entity in the database.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static TEntity Get<TEntity>(this IDbConnection connection, object[] ids, IDbTransaction? transaction = null) where TEntity : class
+        public static TEntity Get<TEntity>(this IDbConnection connection, object[] ids, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null) where TEntity : class
         {
             if (ids.Length == 1)
             {
-                return Get<TEntity>(connection, ids[0], transaction);
+                return Get<TEntity>(connection, ids[0], tableNameResolver, transaction);
             }
 
-            var sql = BuildGetByIds(connection, typeof(TEntity), ids, out var parameters);
+            var sql = BuildGetByIds(connection, typeof(TEntity), ids, tableNameResolver, out var parameters);
             LogQuery<TEntity>(sql);
             return connection.QueryFirstOrDefault<TEntity>(sql, parameters, transaction);
         }
@@ -105,8 +105,8 @@ namespace Dommel
         /// <param name="connection">The connection to the database. This can either be open or closed.</param>
         /// <param name="ids">The id of the entity in the database.</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, params object[] ids) where TEntity : class
-            => GetAsync<TEntity>(connection, ids, transaction: null, cancellationToken: default);
+        public static Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, params object[] ids) where TEntity : class
+            => GetAsync<TEntity>(connection, ids, tableNameResolver, transaction: null, cancellationToken: default);
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TEntity"/> with the specified id.
@@ -117,23 +117,23 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id.</returns>
-        public static async Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object[] ids, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
+        public static async Task<TEntity> GetAsync<TEntity>(this IDbConnection connection, object[] ids, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default)
             where TEntity : class
         {
             if (ids.Length == 1)
             {
-                return await GetAsync<TEntity>(connection, ids[0], transaction);
+                return await GetAsync<TEntity>(connection, ids[0], tableNameResolver, transaction);
             }
 
-            var sql = BuildGetByIds(connection, typeof(TEntity), ids, out var parameters);
+            var sql = BuildGetByIds(connection, typeof(TEntity), ids, tableNameResolver, out var parameters);
             LogQuery<TEntity>(sql);
             return await connection.QueryFirstOrDefaultAsync<TEntity>(new CommandDefinition(sql, parameters, transaction, cancellationToken: cancellationToken));
         }
 
-        internal static string BuildGetByIds(IDbConnection connection, Type type, object[] ids, out DynamicParameters parameters)
+        internal static string BuildGetByIds(IDbConnection connection, Type type, object[] ids, ITableNameResolver tableNameResolver, out DynamicParameters parameters)
         {
             var sqlBuilder = GetSqlBuilder(connection);
-                var tableName = Resolvers.Table(type, sqlBuilder);
+                var tableName = Resolvers.Table(type, sqlBuilder, tableNameResolver);
             var cacheKey = new QueryCacheKey(QueryCacheType.GetByMultipleIds, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
@@ -181,9 +181,9 @@ namespace Dommel
         /// </param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>A collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static IEnumerable<TEntity> GetAll<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null, bool buffered = true) where TEntity : class
+        public static IEnumerable<TEntity> GetAll<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true) where TEntity : class
         {
-            var sql = BuildGetAllQuery(connection, typeof(TEntity));
+            var sql = BuildGetAllQuery(connection, typeof(TEntity), tableNameResolver);
             LogQuery<TEntity>(sql);
             return connection.Query<TEntity>(sql, transaction: transaction, buffered: buffered);
         }
@@ -196,17 +196,17 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>A collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static Task<IEnumerable<TEntity>> GetAllAsync<TEntity>(this IDbConnection connection, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TEntity : class
+        public static Task<IEnumerable<TEntity>> GetAllAsync<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TEntity : class
         {
-            var sql = BuildGetAllQuery(connection, typeof(TEntity));
+            var sql = BuildGetAllQuery(connection, typeof(TEntity), tableNameResolver);
             LogQuery<TEntity>(sql);
             return connection.QueryAsync<TEntity>(new CommandDefinition(sql, transaction: transaction, cancellationToken: cancellationToken));
         }
 
-        internal static string BuildGetAllQuery(IDbConnection connection, Type type)
+        internal static string BuildGetAllQuery(IDbConnection connection, Type type, ITableNameResolver tableNameResolver)
         {
             var sqlBuilder = GetSqlBuilder(connection);
-            var tableName = Resolvers.Table(type, sqlBuilder);
+            var tableName = Resolvers.Table(type, sqlBuilder, tableNameResolver);
             var cacheKey = new QueryCacheKey(QueryCacheType.GetAll, sqlBuilder, type, tableName);
             if (!QueryCache.TryGetValue(cacheKey, out var sql))
             {
@@ -230,9 +230,9 @@ namespace Dommel
         /// </param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>A paged collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static IEnumerable<TEntity> GetPaged<TEntity>(this IDbConnection connection, int pageNumber, int pageSize, IDbTransaction? transaction = null, bool buffered = true) where TEntity : class
+        public static IEnumerable<TEntity> GetPaged<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, int pageNumber, int pageSize, IDbTransaction? transaction = null, bool buffered = true) where TEntity : class
         {
-            var sql = BuildPagedQuery(connection, typeof(TEntity), pageNumber, pageSize);
+            var sql = BuildPagedQuery(connection, typeof(TEntity), tableNameResolver, pageNumber, pageSize);
             LogQuery<TEntity>(sql);
             return connection.Query<TEntity>(sql, transaction: transaction, buffered: buffered);
         }
@@ -247,17 +247,17 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>A paged collection of entities of type <typeparamref name="TEntity"/>.</returns>
-        public static Task<IEnumerable<TEntity>> GetPagedAsync<TEntity>(this IDbConnection connection, int pageNumber, int pageSize, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TEntity : class
+        public static Task<IEnumerable<TEntity>> GetPagedAsync<TEntity>(this IDbConnection connection, ITableNameResolver tableNameResolver, int pageNumber, int pageSize, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TEntity : class
         {
-            var sql = BuildPagedQuery(connection, typeof(TEntity), pageNumber, pageSize);
+            var sql = BuildPagedQuery(connection, typeof(TEntity), tableNameResolver, pageNumber, pageSize);
             LogQuery<TEntity>(sql);
             return connection.QueryAsync<TEntity>(new CommandDefinition(sql, transaction: transaction, cancellationToken: cancellationToken));
         }
 
-        internal static string BuildPagedQuery(IDbConnection connection, Type type, int pageNumber, int pageSize)
+        internal static string BuildPagedQuery(IDbConnection connection, Type type, ITableNameResolver tableNameResolver, int pageNumber, int pageSize)
         {
             // Start with the select query part
-            var sql = BuildGetAllQuery(connection, type);
+            var sql = BuildGetAllQuery(connection, type, tableNameResolver);
 
             // Append the paging part including the order by
             var keyColumns = Resolvers.KeyProperties(type).Select(p => Resolvers.Column(p.Property, connection));

--- a/src/Bornlogic.Dapper.Dommel/MultiMap.cs
+++ b/src/Bornlogic.Dapper.Dommel/MultiMap.cs
@@ -23,8 +23,8 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, TReturn>(this IDbConnection connection, object id, Func<T1, T2, TReturn> map, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
-            => MultiMap<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, transaction).FirstOrDefault();
+        public static TReturn Get<T1, T2, TReturn>(this IDbConnection connection, object id, Func<T1, T2, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
+            => MultiMap<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -39,8 +39,8 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, TReturn>(this IDbConnection connection, object id, Func<T1, T2, TReturn> map, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
-            => (await MultiMapAsync<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
+        public static async Task<TReturn> GetAsync<T1, T2, TReturn>(this IDbConnection connection, object id, Func<T1, T2, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
+            => (await MultiMapAsync<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -55,8 +55,8 @@ namespace Dommel
         /// <param name="map">The mapping to perform on the entities in the result set.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, TReturn> map, IDbTransaction? transaction = null) where TReturn : class
-            => MultiMap<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, transaction).FirstOrDefault();
+        public static TReturn Get<T1, T2, T3, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null) where TReturn : class
+            => MultiMap<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -72,8 +72,8 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, TReturn> map, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
-            => (await MultiMapAsync<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
+        public static async Task<TReturn> GetAsync<T1, T2, T3, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
+            => (await MultiMapAsync<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -89,8 +89,8 @@ namespace Dommel
         /// <param name="map">The mapping to perform on the entities in the result set.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, TReturn> map, IDbTransaction? transaction = null) where TReturn : class
-            => MultiMap<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id, transaction).FirstOrDefault();
+        public static TReturn Get<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null) where TReturn : class
+            => MultiMap<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -107,8 +107,8 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, TReturn> map, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
-            => (await MultiMapAsync<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
+        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
+            => (await MultiMapAsync<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -125,9 +125,9 @@ namespace Dommel
         /// <param name="map">The mapping to perform on the entities in the result set.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, TReturn> map,
+        public static TReturn Get<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null) where TReturn : class
-            => MultiMap<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id, transaction).FirstOrDefault();
+            => MultiMap<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -145,8 +145,8 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, TReturn> map, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
-            => (await MultiMapAsync<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
+        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
+            => (await MultiMapAsync<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -164,8 +164,8 @@ namespace Dommel
         /// <param name="map">The mapping to perform on the entities in the result set.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, T6, TReturn> map, IDbTransaction? transaction = null) where TReturn : class
-            => MultiMap<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id, transaction).FirstOrDefault();
+        public static TReturn Get<T1, T2, T3, T4, T5, T6, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, T6, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null) where TReturn : class
+            => MultiMap<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -187,9 +187,9 @@ namespace Dommel
         public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, T6, TReturn>(
             this IDbConnection connection,
             object id,
-            Func<T1, T2, T3, T4, T5, T6, TReturn> map,
+            Func<T1, T2, T3, T4, T5, T6, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
-            CancellationToken cancellationToken = default) => (await MultiMapAsync<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
+            CancellationToken cancellationToken = default) => (await MultiMapAsync<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id, tableNameResolver, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -208,8 +208,8 @@ namespace Dommel
         /// <param name="map">The mapping to perform on the entities in the result set.</param>
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static TReturn Get<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map, IDbTransaction? transaction = null) where TReturn : class
-            => MultiMap<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id, transaction).FirstOrDefault();
+        public static TReturn Get<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null) where TReturn : class
+            => MultiMap<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id, tableNameResolver, transaction).FirstOrDefault();
 
         /// <summary>
         /// Retrieves the entity of type <typeparamref name="TReturn"/> with the specified id
@@ -229,8 +229,8 @@ namespace Dommel
         /// <param name="transaction">Optional transaction for the command.</param>
         /// <param name="cancellationToken">Optional cancellation token for the command.</param>
         /// <returns>The entity with the corresponding id joined with the specified types.</returns>
-        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
-            => (await MultiMapAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
+        public static async Task<TReturn> GetAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(this IDbConnection connection, object id, Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, CancellationToken cancellationToken = default) where TReturn : class
+            => (await MultiMapAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id, tableNameResolver, transaction, cancellationToken: cancellationToken)).FirstOrDefault();
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -252,9 +252,9 @@ namespace Dommel
         /// </returns>
         public static IEnumerable<TReturn> GetAll<T1, T2, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, TReturn> map,
+            Func<T1, T2, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
-            bool buffered = true) => MultiMap<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered);
+            bool buffered = true) => MultiMap<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -277,10 +277,10 @@ namespace Dommel
         /// </returns>
         public static Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, TReturn> map,
+            Func<T1, T2, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
             bool buffered = true,
-              CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered, cancellationToken: cancellationToken);
+              CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, DontMap, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -302,10 +302,11 @@ namespace Dommel
         /// joined with the specified type types.
         /// </returns>
         public static IEnumerable<TReturn> GetAll<T1, T2, T3, TReturn>(
-            this IDbConnection connection,
+            this IDbConnection connection, ITableNameResolver tableNameResolver,
+
             Func<T1, T2, T3, TReturn> map,
             IDbTransaction? transaction = null,
-            bool buffered = true) => MultiMap<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered);
+            bool buffered = true) => MultiMap<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -329,10 +330,10 @@ namespace Dommel
         /// </returns>
         public static Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, TReturn> map,
+            Func<T1, T2, T3, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
             bool buffered = true,
-              CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered, cancellationToken: cancellationToken);
+              CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, DontMap, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -356,9 +357,9 @@ namespace Dommel
         /// </returns>
         public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, TReturn> map,
+            Func<T1, T2, T3, T4, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
-            bool buffered = true) => MultiMap<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered);
+            bool buffered = true) => MultiMap<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -383,10 +384,10 @@ namespace Dommel
         /// </returns>
         public static Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, TReturn> map,
+            Func<T1, T2, T3, T4, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
             bool buffered = true,
-              CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered, cancellationToken: cancellationToken);
+              CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, DontMap, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -411,9 +412,9 @@ namespace Dommel
         /// </returns>
         public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, T5, TReturn> map,
+            Func<T1, T2, T3, T4, T5, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
-            bool buffered = true) => MultiMap<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered);
+            bool buffered = true) => MultiMap<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -439,10 +440,10 @@ namespace Dommel
         /// </returns>
         public static Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, T5, TReturn> map,
+            Func<T1, T2, T3, T4, T5, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
             bool buffered = true,
-             CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id: null, transaction, buffered, cancellationToken: cancellationToken);
+             CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, T5, DontMap, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -468,9 +469,9 @@ namespace Dommel
         /// </returns>
         public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, T6, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, T5, T6, TReturn> map,
+            Func<T1, T2, T3, T4, T5, T6, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
-            bool buffered = true) => MultiMap<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id: null, transaction, buffered);
+            bool buffered = true) => MultiMap<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -497,10 +498,11 @@ namespace Dommel
         /// </returns>
         public static Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, T6, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, T5, T6, TReturn> map,
+            Func<T1, T2, T3, T4, T5, T6, TReturn> map, ITableNameResolver tableNameResolver,
+
             IDbTransaction? transaction = null,
             bool buffered = true,
-            CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id: null, transaction, buffered, cancellationToken: cancellationToken);
+            CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, T5, T6, DontMap, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered, cancellationToken: cancellationToken);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -527,9 +529,9 @@ namespace Dommel
         /// </returns>
         public static IEnumerable<TReturn> GetAll<T1, T2, T3, T4, T5, T6, T7, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map,
+            Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map, ITableNameResolver tableNameResolver,
             IDbTransaction? transaction = null,
-            bool buffered = true) => MultiMap<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id: null, transaction, buffered);
+            bool buffered = true) => MultiMap<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered);
 
         /// <summary>
         /// Retrieves all the entities of type <typeparamref name="TReturn"/>
@@ -557,12 +559,14 @@ namespace Dommel
         /// </returns>
         public static Task<IEnumerable<TReturn>> GetAllAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(
             this IDbConnection connection,
-            Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map,
-            IDbTransaction? transaction = null,
-            bool buffered = true,
-            CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id: null, transaction, buffered, cancellationToken: cancellationToken);
+            Func<T1, T2, T3, T4, T5, T6, T7, TReturn> map, ITableNameResolver tableNameResolver,
 
-        private static IEnumerable<TReturn> MultiMap<T1, T2, T3, T4, T5, T6, T7, TReturn>(IDbConnection connection, Delegate map, object? id, IDbTransaction? transaction = null, bool buffered = true)
+            IDbTransaction? transaction = null,
+
+            bool buffered = true,
+            CancellationToken cancellationToken = default) => MultiMapAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(connection, map, id: null, tableNameResolver, transaction, buffered, cancellationToken: cancellationToken);
+
+        private static IEnumerable<TReturn> MultiMap<T1, T2, T3, T4, T5, T6, T7, TReturn>(IDbConnection connection, Delegate map, object? id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true)
         {
             var resultType = typeof(TReturn);
             var includeTypes = new[]
@@ -578,7 +582,7 @@ namespace Dommel
             .Where(t => t != typeof(DontMap))
             .ToArray();
 
-            var sql = BuildMultiMapQuery(GetSqlBuilder(connection), resultType, includeTypes, id, out var parameters);
+            var sql = BuildMultiMapQuery(GetSqlBuilder(connection), resultType, includeTypes, id, tableNameResolver, out var parameters);
             LogQuery<TReturn>(sql);
             var splitOn = CreateSplitOn(includeTypes);
 
@@ -594,7 +598,7 @@ namespace Dommel
             };
         }
 
-        private static Task<IEnumerable<TReturn>> MultiMapAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(IDbConnection connection, Delegate map, object? id, IDbTransaction? transaction = null, bool buffered = true, CancellationToken cancellationToken = default)
+        private static Task<IEnumerable<TReturn>> MultiMapAsync<T1, T2, T3, T4, T5, T6, T7, TReturn>(IDbConnection connection, Delegate map, object? id, ITableNameResolver tableNameResolver, IDbTransaction? transaction = null, bool buffered = true, CancellationToken cancellationToken = default)
         {
             var resultType = typeof(TReturn);
             var includeTypes = new[]
@@ -610,7 +614,7 @@ namespace Dommel
             .Where(t => t != typeof(DontMap))
             .ToArray();
 
-            var sql = BuildMultiMapQuery(GetSqlBuilder(connection), resultType, includeTypes, id, out var parameters);
+            var sql = BuildMultiMapQuery(GetSqlBuilder(connection), resultType, includeTypes, id, tableNameResolver, out var parameters);
             LogQuery<TReturn>(sql);
             var splitOn = CreateSplitOn(includeTypes);
 
@@ -639,20 +643,20 @@ namespace Dommel
                 .Select(p => ColumnNameResolver.ResolveColumnName(p.Property)));
         }
 
-        internal static string BuildMultiMapQuery(ISqlBuilder sqlBuilder, Type resultType, Type[] includeTypes, object? id, out DynamicParameters? parameters)
+        internal static string BuildMultiMapQuery(ISqlBuilder sqlBuilder, Type resultType, Type[] includeTypes, object? id, ITableNameResolver tableNameResolver, out DynamicParameters? parameters)
         {
-            var resultTableName = Resolvers.Table(resultType, sqlBuilder);
+            var resultTableName = Resolvers.Table(resultType, sqlBuilder, tableNameResolver);
             var resultTableKeyColumnName = Resolvers.Column(Resolvers.KeyProperties(resultType).Single().Property, sqlBuilder);
             var sql = $"select * from {resultTableName}";
 
             // Determine the table to join with.
             var sourceType = includeTypes[0];
-            var sourceTableName = Resolvers.Table(sourceType, sqlBuilder);
+            var sourceTableName = Resolvers.Table(sourceType, sqlBuilder, tableNameResolver);
             for (var i = 1; i < includeTypes.Length; i++)
             {
                 // Determine the table name of the joined table.
                 var includeType = includeTypes[i];
-                var foreignKeyTableName = Resolvers.Table(includeType, sqlBuilder);
+                var foreignKeyTableName = Resolvers.Table(includeType, sqlBuilder, tableNameResolver);
 
                 // Determine the foreign key and the relationship type.
                 var foreignKeyProperty = Resolvers.ForeignKeyProperty(sourceType, includeType, out var relation);

--- a/src/Bornlogic.Dapper.Dommel/Resolvers.cs
+++ b/src/Bornlogic.Dapper.Dommel/Resolvers.cs
@@ -86,8 +86,8 @@ namespace Dommel
         /// <param name="type">The <see cref="Type"/> to get the table name for.</param>
         /// <param name="connection">The database connection instance.</param>
         /// <returns>The table name in the database for <paramref name="type"/>.</returns>
-        public static string Table(Type type, IDbConnection connection) =>
-            Table(type, DommelMapper.GetSqlBuilder(connection));
+        public static string Table(Type type, IDbConnection connection, ITableNameResolver tableNameResolver) =>
+            Table(type, DommelMapper.GetSqlBuilder(connection), tableNameResolver);
 
         /// <summary>
         /// Gets the name of the table in the database for the specified type,
@@ -96,15 +96,15 @@ namespace Dommel
         /// <param name="type">The <see cref="Type"/> to get the table name for.</param>
         /// <param name="sqlBuilder">The SQL builder instance.</param>
         /// <returns>The table name in the database for <paramref name="type"/>.</returns>
-        public static string Table(Type type, ISqlBuilder sqlBuilder)
+        public static string Table(Type type, ISqlBuilder sqlBuilder, ITableNameResolver tableNameResolver)
         {
             var name = "";
-            var tableName = DommelMapper.TableNameResolver.ResolveTableName(type);
+            var tableName = tableNameResolver.ResolveTableName(type);
 
             // Dots are used to define a schema which should be quoted separately
             if (tableName.Contains('.'))
             {
-                name = string.Join(".", DommelMapper.TableNameResolver
+                name = string.Join(".", tableNameResolver
                     .ResolveTableName(type)
                     .Split('.')
                     .Select(x => sqlBuilder.QuoteIdentifier(x)));

--- a/src/Bornlogic.Dapper.Dommel/SqlExpression.cs
+++ b/src/Bornlogic.Dapper.Dommel/SqlExpression.cs
@@ -47,9 +47,9 @@ namespace Dommel
         /// Selects all columns from <typeparamref name="TEntity"/>.
         /// </summary>
         /// <returns>The current <see cref="SqlExpression{TEntity}"/> instance.</returns>
-        public virtual SqlExpression<TEntity> Select()
+        public virtual SqlExpression<TEntity> Select(ITableNameResolver tableNameResolver)
         {
-            _selectQuery = $"select * from {Resolvers.Table(typeof(TEntity), SqlBuilder)}";
+            _selectQuery = $"select * from {Resolvers.Table(typeof(TEntity), SqlBuilder, tableNameResolver)}";
             return this;
         }
 
@@ -59,7 +59,7 @@ namespace Dommel
         /// <param name="selector">The columns to select.
         /// E.g. <code>x => new { x.Foo, x.Bar }</code>.</param>
         /// <returns>The current <see cref="SqlExpression{TEntity}"/> instance.</returns>
-        public virtual SqlExpression<TEntity> Select(Func<TEntity, object> selector)
+        public virtual SqlExpression<TEntity> Select(Func<TEntity, object> selector, ITableNameResolver tableNameResolver)
         {
             if (selector == null)
             {
@@ -79,7 +79,7 @@ namespace Dommel
             var columns = props.Select(p => Resolvers.Column(p, SqlBuilder));
 
             // Create the select query
-            var tableName = Resolvers.Table(EntityType, SqlBuilder);
+            var tableName = Resolvers.Table(EntityType, SqlBuilder, tableNameResolver);
             _selectQuery = $"select {string.Join(", ", columns)} from {tableName}";
             return this;
         }

--- a/test/Bornlogic.Dapper.Dommel.Tests/AnyTests.cs
+++ b/test/Bornlogic.Dapper.Dommel.Tests/AnyTests.cs
@@ -10,14 +10,14 @@ namespace Dommel.Tests
         [Fact]
         public void GeneratesAnyAllSql()
         {
-            var sql = BuildAnyAllSql(SqlBuilder, typeof(Foo));
+            var sql = BuildAnyAllSql(SqlBuilder, typeof(Foo), new DefaultTableNameResolver());
             Assert.Equal($"select 1 from [Foos] {SqlBuilder.LimitClause(1)}", sql);
         }
 
         [Fact]
         public void GeneratesAnySql()
         {
-            var sql = BuildAnySql<Foo>(SqlBuilder, x => x.Bar == "Baz", out var parameters);
+            var sql = BuildAnySql<Foo>(SqlBuilder, x => x.Bar == "Baz", new DefaultTableNameResolver(), out var parameters);
             Assert.Equal($"select 1 from [Foos] where ([Bar] = @p1) {SqlBuilder.LimitClause(1)}", sql);
             Assert.Single(parameters.ParameterNames);
         }

--- a/test/Bornlogic.Dapper.Dommel.Tests/CountTests.cs
+++ b/test/Bornlogic.Dapper.Dommel.Tests/CountTests.cs
@@ -10,14 +10,14 @@ namespace Dommel.Tests
         [Fact]
         public void GeneratesCountAllSql()
         {
-            var sql = BuildCountAllSql(SqlBuilder, typeof(Foo));
+            var sql = BuildCountAllSql(SqlBuilder, typeof(Foo), new DefaultTableNameResolver());
             Assert.Equal("select count(*) from [Foos]", sql);
         }
 
         [Fact]
         public void GeneratesCountSql()
         {
-            var sql = BuildCountSql<Foo>(SqlBuilder, x => x.Bar == "Baz", out var parameters);
+            var sql = BuildCountSql<Foo>(SqlBuilder, x => x.Bar == "Baz", new DefaultTableNameResolver(), out var parameters);
             Assert.Equal("select count(*) from [Foos] where ([Bar] = @p1)", sql);
             Assert.Single(parameters.ParameterNames);
         }

--- a/test/Bornlogic.Dapper.Dommel.Tests/MultiMapTests.cs
+++ b/test/Bornlogic.Dapper.Dommel.Tests/MultiMapTests.cs
@@ -10,7 +10,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_OneToOne()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category) }, null, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category) }, null, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` left join `Categories` on `Products`.`CategoryId` = `Categories`.`Id`";
             Assert.Equal(expectedQuery, query);
             Assert.Null(parameters);
@@ -19,7 +19,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_OneToOneSingle()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category) }, 1, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category) }, 1, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` left join `Categories` on `Products`.`CategoryId` = `Categories`.`Id` where `Products`.`Id` = @Id";
             Assert.Equal(expectedQuery, query);
             Assert.Equal("Id", Assert.Single(parameters?.ParameterNames));
@@ -28,7 +28,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_OneToMany()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption) }, null, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption) }, null, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` left join `ProductOptions` on `Products`.`Id` = `ProductOptions`.`ProductId`";
             Assert.Equal(expectedQuery, query);
             Assert.Null(parameters);
@@ -37,7 +37,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_OneToManySingle()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption) }, 1, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption) }, 1, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` left join `ProductOptions` on `Products`.`Id` = `ProductOptions`.`ProductId` where `Products`.`Id` = @Id";
             Assert.Equal(expectedQuery, query);
             Assert.Equal("Id", Assert.Single(parameters?.ParameterNames));
@@ -46,7 +46,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_OneToOneOneToMany()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category), typeof(ProductOption) }, null, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category), typeof(ProductOption) }, null, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` " +
                 "left join `Categories` on `Products`.`CategoryId` = `Categories`.`Id` " +
                 "left join `ProductOptions` on `Products`.`Id` = `ProductOptions`.`ProductId`";
@@ -57,7 +57,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_BuildMultiMapQuery_OneToOneOneToManySingle()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category), typeof(ProductOption) }, 1, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(Category), typeof(ProductOption) }, 1, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` " +
                 "left join `Categories` on `Products`.`CategoryId` = `Categories`.`Id` " +
                 "left join `ProductOptions` on `Products`.`Id` = `ProductOptions`.`ProductId` " +
@@ -69,7 +69,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_OneToManyOneToOne()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption), typeof(Category) }, null, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption), typeof(Category) }, null, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` " +
                 "left join `ProductOptions` on `Products`.`Id` = `ProductOptions`.`ProductId` " +
                 "left join `Categories` on `Products`.`CategoryId` = `Categories`.`Id`";
@@ -80,7 +80,7 @@ namespace Dommel.Tests
         [Fact]
         public void BuildMultiMapQuery_BuildMultiMapQuery_OneToManyOneToOneSingle()
         {
-            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption), typeof(Category) }, 1, out var parameters);
+            var query = BuildMultiMapQuery(_sqlBuilder, typeof(Product), new[] { typeof(Product), typeof(ProductOption), typeof(Category) }, 1, new DefaultTableNameResolver(), out var parameters);
             var expectedQuery = "select * from `Products` " +
                 "left join `ProductOptions` on `Products`.`Id` = `ProductOptions`.`ProductId` " +
                 "left join `Categories` on `Products`.`CategoryId` = `Categories`.`Id` " +

--- a/test/Bornlogic.Dapper.Dommel.Tests/ParameterPrefixTest.cs
+++ b/test/Bornlogic.Dapper.Dommel.Tests/ParameterPrefixTest.cs
@@ -10,7 +10,7 @@ namespace Dommel.Tests
         [Fact]
         public void Get()
         {
-            var sql = BuildGetById(SqlBuilder, typeof(Foo), new[] { (object)1 }, out var parameters);
+            var sql = BuildGetById(SqlBuilder, typeof(Foo), new[] { (object)1 }, new DefaultTableNameResolver(), out var parameters);
             Assert.Equal("select * from Foos where Id = #Id", sql);
             Assert.Single(parameters.ParameterNames);
         }
@@ -33,21 +33,21 @@ namespace Dommel.Tests
         [Fact]
         public void TestInsert()
         {
-            var sql = BuildInsertQuery(SqlBuilder, typeof(Foo));
+            var sql = BuildInsertQuery(SqlBuilder, typeof(Foo), new DefaultTableNameResolver());
             Assert.Equal("insert into Foos (Bar) values (#Bar); select last_insert_rowid() id", sql);
         }
 
         [Fact]
         public void TestUpdate()
         {
-            var sql = BuildUpdateQuery(SqlBuilder, typeof(Foo));
+            var sql = BuildUpdateQuery(SqlBuilder, typeof(Foo), new DefaultTableNameResolver());
             Assert.Equal("update Foos set Bar = #Bar where Id = #Id", sql);
         }
 
         [Fact]
         public void TestDelete()
         {
-            var sql = BuildDeleteQuery(SqlBuilder, typeof(Foo));
+            var sql = BuildDeleteQuery(SqlBuilder, typeof(Foo), new DefaultTableNameResolver());
             Assert.Equal("delete from Foos where Id = #Id", sql);
         }
 

--- a/test/Bornlogic.Dapper.Dommel.Tests/ProjectTests.cs
+++ b/test/Bornlogic.Dapper.Dommel.Tests/ProjectTests.cs
@@ -11,7 +11,7 @@ namespace Dommel.Tests
         [Fact]
         public void ProjectById()
         {
-            var sql = BuildProjectById(SqlBuilder, typeof(ProjectedFoo), 42, out var parameters);
+            var sql = BuildProjectById(SqlBuilder, typeof(ProjectedFoo), 42, new DefaultTableNameResolver(),out var parameters);
             Assert.Equal("select [Id], [Name], [DateUpdated] from [ProjectedFoos] where [Id] = @Id", sql);
             Assert.NotNull(parameters);
         }
@@ -19,14 +19,14 @@ namespace Dommel.Tests
         [Fact]
         public void ProjectAll()
         {
-            var sql = BuildProjectAllQuery(SqlBuilder, typeof(ProjectedFoo));
+            var sql = BuildProjectAllQuery(SqlBuilder, typeof(ProjectedFoo), new DefaultTableNameResolver());
             Assert.Equal("select [Id], [Name], [DateUpdated] from [ProjectedFoos]", sql);
         }
 
         [Fact]
         public void ProjectPaged()
         {
-            var sql = BuildProjectPagedQuery(SqlBuilder, typeof(ProjectedFoo), 1, 5);
+            var sql = BuildProjectPagedQuery(SqlBuilder, typeof(ProjectedFoo), new DefaultTableNameResolver(), 1, 5);
             Assert.Equal("select [Id], [Name], [DateUpdated] from [ProjectedFoos] order by [Id] offset 0 rows fetch next 5 rows only", sql);
         }
 

--- a/test/Bornlogic.Dapper.Dommel.Tests/ResolversTests.cs
+++ b/test/Bornlogic.Dapper.Dommel.Tests/ResolversTests.cs
@@ -10,15 +10,15 @@ namespace Dommel.Tests
         [Fact]
         public void Table_WithSchema()
         {
-            Assert.Equal("[dbo].[Qux]", Resolvers.Table(typeof(FooQux), _sqlBuilder));
-            Assert.Equal("[foo].[dbo].[Qux]", Resolvers.Table(typeof(FooDboQux), _sqlBuilder));
+            Assert.Equal("[dbo].[Qux]", Resolvers.Table(typeof(FooQux), _sqlBuilder, new DefaultTableNameResolver()));
+            Assert.Equal("[foo].[dbo].[Qux]", Resolvers.Table(typeof(FooDboQux), _sqlBuilder, new DefaultTableNameResolver()));
         }
 
         [Fact]
         public void Table_NoCacheConflictNestedClass()
         {
-            Assert.Equal("[BarA]", Resolvers.Table(typeof(Foo.Bar), _sqlBuilder));
-            Assert.Equal("[BarB]", Resolvers.Table(typeof(Baz.Bar), _sqlBuilder));
+            Assert.Equal("[BarA]", Resolvers.Table(typeof(Foo.Bar), _sqlBuilder, new DefaultTableNameResolver()));
+            Assert.Equal("[BarB]", Resolvers.Table(typeof(Baz.Bar), _sqlBuilder, new DefaultTableNameResolver()));
         }
 
         [Fact]

--- a/test/Bornlogic.Dapper.Dommel.Tests/SqlExpressions/SelectExpressionTests.cs
+++ b/test/Bornlogic.Dapper.Dommel.Tests/SqlExpressions/SelectExpressionTests.cs
@@ -11,18 +11,18 @@ namespace Dommel.Tests
         public void Select_AllProperties()
         {
             var sql = _sqlExpression
-                .Select()
+                .Select(new DefaultTableNameResolver())
                 .ToSql();
             Assert.Equal("select * from [Products]", sql);
         }
 
         [Fact]
-        public void Select_ThrowsForNullSelector() => Assert.Throws<ArgumentNullException>("selector", () => _sqlExpression.Select(null!));
+        public void Select_ThrowsForNullSelector() => Assert.Throws<ArgumentNullException>("selector", () => _sqlExpression.Select(null!, new DefaultTableNameResolver()));
 
         [Fact]
         public void Select_ThrowsForEmptyProjection()
         {
-            var ex = Assert.Throws<ArgumentException>("selector", () => _sqlExpression.Select(x => new object()));
+            var ex = Assert.Throws<ArgumentException>("selector", () => _sqlExpression.Select(x => new object(), new DefaultTableNameResolver()));
             Assert.Equal(new ArgumentException("Projection over type 'Product' yielded no properties.", "selector").Message, ex.Message);
         }
 
@@ -30,7 +30,7 @@ namespace Dommel.Tests
         public void Select_SingleProperty()
         {
             var sql = _sqlExpression
-                .Select(p => new { p.Id })
+                .Select(p => new { p.Id }, new DefaultTableNameResolver())
                 .ToSql();
             Assert.Equal("select [Id] from [Products]", sql);
         }
@@ -39,7 +39,7 @@ namespace Dommel.Tests
         public void Select_MultipleProperties()
         {
             var sql = _sqlExpression
-                .Select(p => new { p.Id, p.Name })
+                .Select(p => new { p.Id, p.Name }, new DefaultTableNameResolver())
                 .ToSql();
             Assert.Equal("select [Id], [Name] from [Products]", sql);
         }


### PR DESCRIPTION
Estou repassando a interface "ITableNameResolver" como parametro em todos os metodos, pois atualmente ela está sendo configurada numa classe estática. Isso está impossibilidade o uso fácil/simples de table resolver ligado ao Multi Tenancy.

Ao remover da classe estática, e repassar por parametro nos builders e afins, fica fácil de ter injetado qualquer implementação dessa interface nas classes acima (como nas nossas libs de repository) e ter um jeito fácil de definir a schema da vez baseado no Tenant.

A maior dificuldade encontrada foi quando usamos essa lib junto com worker que recebem itens da fila e injetam o tenant num contexto do Autofac.

Essa alteração não impacta muito, a classe acima só tem q repassar esse valor. Podendo até ser a classe "default" se quiser.